### PR TITLE
Fixed pyhon file name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ with your world.
 
 Usage
 =====
-You can read the program help running: "python region-fixer.py --help"
+You can read the program help running: "python regionfixer.py --help"
 
 For usage examples and more info visit the wiki:
 


### PR DESCRIPTION
This is a minor fix and is only doing it to the readme file