### PR TITLE
Since 1.17, chunks may not have the "Entities" tag

### DIFF
--- a/regionfixer_core/scan.py
+++ b/regionfixer_core/scan.py
@@ -913,11 +913,20 @@ def scan_chunk(region_file, coords, global_coords, entity_limit):
             # Level chunk
             try:
                 data_coords = world.get_chunk_data_coords(chunk)
-                num_entities = len(chunk["Level"]["Entities"])
+                
+                # Since snapshot 20w45a (1.17), entities MAY BE separated
+                if chunk["DataVersion"].value >= 2681 :
+                    if "Entities" in chunk["Level"] :
+                        num_entities = len(chunk["Level"]["Entities"])
+                    else :
+                        num_entities = None
+                else :
+                    num_entities = len(chunk["Level"]["Entities"])
+                
                 if data_coords != global_coords:
                     # wrong located chunk
                     status = c.CHUNK_WRONG_LOCATED
-                elif num_entities > el:
+                elif num_entities != None and num_entities > el:
                     # too many entities in the chunk
                     status = c.CHUNK_TOO_MANY_ENTITIES
                 else:


### PR DESCRIPTION
Hello again ! ^^
This a a fix proposal for my issue #165 (Please read this first).
Since snapshot 20w45a (Data version 2681), chunks may not have the `Entities` tag.
It's not mandatory, but we still pass the verification of the presence of this tag.
Note : The commit doesn't contain a scanner for Anvil files in the new `entities` folder.
Really important note : I am not familiar with the Region-Fixer code and architecture, so this commit can possibly lead to problems and bugs. Thanks @Fenixin to be careful before merging this PR. ^^
Have a nice day !