### PR TITLE
Scan new "entities" folders (>=1.17), fix scan of "poi" folders

### DIFF
--- a/regionfixer_core/constants.py
+++ b/regionfixer_core/constants.py
@@ -237,8 +237,16 @@ for problem in CHUNK_PROBLEMS:
                                     CHUNK_PROBLEMS_ARGS[problem]))
 
 # Dimension names:
-DIMENSION_NAMES = {"region": "Overworld",
+DIMENSION_NAMES = {"": "Overworld",
                    "DIM1": "The End",
-                   "DIM-1": "Nether",
-                   "poi": "POIs"
+                   "DIM-1": "Nether"
                    }
+
+# Region files types
+LEVEL_DIR = "region"
+POI_DIR = "poi"
+ENTITIES_DIR = "entities"
+REGION_TYPES_NAMES = {LEVEL_DIR: ("level/region", "Level/Region"),
+                      POI_DIR: ("POIs", "POIs"),
+                      ENTITIES_DIR: ("entities", "Entities" )
+                      }

--- a/regionfixer_core/scan.py
+++ b/regionfixer_core/scan.py
@@ -663,11 +663,15 @@ def console_scan_world(world_obj, processes, entity_limit, remove_entities,
     # Scan the world directory
     print("World info:")
 
-    print(("There are {0} region files, {1} player files and {2} data"
-           " files in the world directory.").format(
-               w.get_number_regions(),
-               len(w.players) + len(w.old_players),
-               len(w.data_files)))
+    counters = w.get_number_regions()
+    if c.LEVEL_DIR in counters:
+        print(" - {0} region/level files,".format(counters[c.LEVEL_DIR]))
+    if c.POI_DIR in counters:
+        print(" - {0} POI files,".format(counters[c.POI_DIR]))
+    if c.ENTITIES_DIR in counters:
+        print(" - {0} entities files,".format(counters[c.ENTITIES_DIR]))
+    print(" - {0} player files,".format(len(w.players) + len(w.old_players)))
+    print(" - and {0} data files.".format(len(w.data_files)))
 
     # check the level.dat
     print("\n{0:-^60}".format(' Checking level.dat '))
@@ -691,7 +695,7 @@ def console_scan_world(world_obj, processes, entity_limit, remove_entities,
     scan_titles = [' Scanning UUID player files ',
                    ' Scanning old format player files ',
                    ' Scanning structures and map data files ',
-                   ' Scanning region files ']
+                   ' Scanning region, POI and entities files ']
     console_scan_loop(scanners, scan_titles, verbose)
     w.scanned = True
 
@@ -956,10 +960,30 @@ def scan_chunk(region_file, coords, global_coords, entity_limit):
             data_coords = None
             num_entities = None
             status = c.CHUNK_OK
-        
+
+        elif "Entities" in chunk:
+            # To check if it's a entities chunk check for the tag "Entities"
+            # If entities are in the region files, the tag "Entities" is in "Level"
+            # https://minecraft.fandom.com/wiki/Entity_format
+            # We use "Entities" as a differentiating factor
+            
+            # Entities chunk
+            data_coords = world.get_chunk_data_coords(chunk)
+            num_entities = len(chunk["Entities"])
+            
+            if data_coords != global_coords:
+                # wrong located chunk
+                status = c.CHUNK_WRONG_LOCATED
+            elif num_entities > el:
+                # too many entities in the chunk
+                status = c.CHUNK_TOO_MANY_ENTITIES
+            else:
+                # chunk ok
+                status = c.CHUNK_OK
+
         else:
             # what is this? we shouldn't reach this part of the code, as far as
-            # we know there is only POI chunks and Level chunks
+            # we know there is only POI chunks, Entities chunks, and Level chunks
             raise AssertionError("Unrecognized scanned chunk in scan_chunk().")
 
     ###############################################


### PR DESCRIPTION
Hello ! ^^
This PR is the following of #166 (Even if it works without) and ends issue #165 (Please read it first).
It also fixes the scan of the `poi` folder for dimension.

Main changes :
* `poi` isn't considered as a dimension anymore. I created a new system (Like dimensions) called "region files type", with currently 3 types : Regions (Level), POIs and Entities. Each dimension (Including the overworld) can have those 3 types or MCA files (Respectively stored in `region`, `poi` and `entities`).
* This types system contains entities files, which is new.
* `RegionSet` objects are differentiated by dimension AND type. This is especially used for wrong located or corrupted chunks replacement from a backup.
* `scan_chunk()` can now recognize and analyze MCA files from `entities`. The differentiating factor is the presence of the `Entities` tag at the root of the chunk. For a region/level file, it is in the `Level` tag.
* `get_number_regions()` now differentiate regions by type. It now returns a dictionary.
* `delete_entities()` can be also used for entities MCA files.

I didn't test, but this commit should also fix issue #162.

Really important note, as last time : I am still not familiar with the Region-Fixer code and architecture, so this commit can possibly lead to problems and bugs. Thanks @Fenixin to be careful before merging this PR. ^^

Have a nice day ! ^^