### PR TITLE
Fix region folder in log files

### DIFF
--- a/regionfixer_core/world.py
+++ b/regionfixer_core/world.py
@@ -889,9 +889,7 @@ class RegionSet(DataSet):
         for r in list(self.keys()):
             if not self[r].has_problems:
                 continue
-            if self.path: rest, dimension_folder = split(self.path)
-            else: dimension_folder = ""
-            text += "Region file: {0}\n".format(join(dimension_folder,self[r].filename))
+            text += "Region file: {0}\n".format(join(self._get_dim_type_string(),self[r].filename))
 
             text += self[r].summary()
             text += " +\n\n"


### PR DESCRIPTION
Hello ! ^^
This is a following of my comment on commit 1df5cc8bb852508f570c366c1fb921e32bd80682.
The problem : In log files, we only see "type" folder (`region`, `poi` or `entities`). For example : `region/r.0.0.mca`.
The fix the logs files, plus reduce code duplication.
It displays for example : `region/r.0.0.mca` for overworld, or `DIM-1/region/r.0.0.mca` for the nether.
Have a nice day !