### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/nbt/README.txt
+++ b/nbt/README.txt
@@ -13,7 +13,7 @@ From the initial specification by Markus Persson::
   amounts of binary data with smaller amounts of additional data.
   An NBT file consists of a single GZIPped Named Tag of type TAG_Compound.
 
-Current specification is on the official [Minecraft Wiki](https://minecraft.gamepedia.com/NBT_format).
+Current specification is on the official [Minecraft Wiki](https://minecraft.wiki/w/NBT_format).
 
 This library is very suited to inspect & edit the Minecraft data files. Provided
 examples demonstrate how to:

--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -2,7 +2,7 @@
 Handles a single chunk of data (16x16x128 blocks) from a Minecraft save.
 
 For more information about the chunck format:
-https://minecraft.gamepedia.com/Chunk_format
+https://minecraft.wiki/w/Chunk_format
 """
 
 from io import BytesIO
@@ -13,7 +13,7 @@ import array
 
 # Legacy numeric block identifiers
 # mapped to alpha identifiers in best effort
-# See https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening
+# See https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
 # TODO: move this map into a separate file
 
 block_ids = {
@@ -143,7 +143,7 @@ class AnvilSection(object):
         self.indexes = []
 
         # Is the section flattened ?
-        # See https://minecraft.gamepedia.com/1.13/Flattening
+        # See https://minecraft.wiki/w/1.13/Flattening
 
         if version == 0 or version == 1343:  # 1343 = MC 1.12.2
             self._init_array(nbt)

--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -2,7 +2,7 @@
 Handle the NBT (Named Binary Tag) data format
 
 For more information about the NBT format:
-https://minecraft.gamepedia.com/NBT_format
+https://minecraft.wiki/w/NBT_format
 """
 
 from struct import Struct, error as StructError

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -2,7 +2,7 @@
 Handle a region file, containing 32x32 chunks.
 
 For more information about the region file format:
-https://minecraft.gamepedia.com/Region_file_format
+https://minecraft.wiki/w/Region_file_format
 """
 
 from .nbt import NBTFile, MalformedFileError

--- a/nbt/world.py
+++ b/nbt/world.py
@@ -2,7 +2,7 @@
 Handles a Minecraft world save using either the Anvil or McRegion format.
 
 For more information about the world format:
-https://minecraft.gamepedia.com/Level_format
+https://minecraft.wiki/w/Level_format
 """
 
 import os, glob, re

--- a/regionfixer_core/scan.py
+++ b/regionfixer_core/scan.py
@@ -986,7 +986,7 @@ def scan_chunk(region_file, coords, global_coords, entity_limit):
         elif chunk_type == c.ENTITIES_DIR:
             # To check if it's a entities chunk check for the tag "Entities"
             # If entities are in the region files, the tag "Entities" is in "Level"
-            # https://minecraft.fandom.com/wiki/Entity_format
+            # https://minecraft.wiki/w/Entity_format
             # We use "Entities" as a differentiating factor
             
             # Entities chunk

--- a/regionfixer_core/scan.py
+++ b/regionfixer_core/scan.py
@@ -972,7 +972,7 @@ def scan_chunk(region_file, coords, global_coords, entity_limit):
         elif chunk_type == c.POI_DIR:
             # To check if it's a POI chunk check for the tag "Sections"
             # If we give a look to the wiki:
-            # https://minecraft.gamepedia.com/Java_Edition_level_format#poi_format
+            # https://minecraft.wiki/w/Java_Edition_level_format#poi_format
             # We can see that there are two TAGs at root of a POI, "Data" and "DataVersion", but
             # in my tests the TAGs at root are "Sections and "DataVersion", no trace of "Data".
             #

--- a/regionfixer_core/world.py
+++ b/regionfixer_core/world.py
@@ -1831,7 +1831,7 @@ def get_chunk_type(chunk):
     """
     
     # DataVersion was introduced in snapshot 15w32a (1.9)
-    # https://minecraft.fandom.com/wiki/Data_version
+    # https://minecraft.wiki/w/Data_version
     data_version = 0
     if "DataVersion" in chunk:
         data_version = chunk["DataVersion"].value


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki